### PR TITLE
Use $watchCollection if it's available.

### DIFF
--- a/checklist-model.js
+++ b/checklist-model.js
@@ -66,11 +66,19 @@ angular.module('checklist-model', [])
         setter(scope.$parent, remove(current, value));
       }
     });
+    
+    // declare one function to be used for both $watch functions
+    function setChecked(newArr, oldArr) {
+        scope.checked = contains(newArr, value);
+    }
 
     // watch original model change
-    scope.$parent.$watch(attrs.checklistModel, function(newArr, oldArr) {
-      scope.checked = contains(newArr, value);
-    }, true);
+    // use the faster $watchCollection method if it's available
+    if (angular.isFunction(scope.$parent.$watchCollection)) {
+        scope.$parent.$watchCollection(attrs.checklistModel, setChecked);
+    } else {
+        scope.$parent.$watch(attrs.checklistModel, setChecked, true);
+    }
   }
 
   return {


### PR DESCRIPTION
$watchCollection was added in Angular 1.1.4 and is considerably faster than a deep $watch.

When checklist-model is large (~1500 items), $watchCollection is more than 1 second faster than a deep $watch.