### PR TITLE
Added "compare on" feature

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "checklist-model",
+  "name": "checklist-model-bm",
   "version": "0.1.3",
   "description": "AngularJS directive for list of checkboxes",
   "author": "https://github.com/vitalets",

--- a/checklist-model.js
+++ b/checklist-model.js
@@ -6,34 +6,30 @@
 angular.module('checklist-model', [])
 .directive('checklistModel', ['$parse', '$compile', function($parse, $compile) {
   // contains
-  function contains(arr, item) {
+  function contains(arr, item, compareOn) {
     if (angular.isArray(arr)) {
       for (var i = 0; i < arr.length; i++) {
-        if (angular.equals(arr[i], item)) {
-          return true;
-        }
+        if (angular.equals(arr[i], item) || arr[i][compareOn] == item[compareOn]) return true;
       }
     }
     return false;
   }
 
   // add
-  function add(arr, item) {
+  function add(arr, item, compareOn) {
     arr = angular.isArray(arr) ? arr : [];
-    for (var i = 0; i < arr.length; i++) {
-      if (angular.equals(arr[i], item)) {
-        return arr;
-      }
-    }    
+    if (contains(arr, item, compareOn)) {
+      return arr;
+    }
     arr.push(item);
     return arr;
   }  
 
   // remove
-  function remove(arr, item) {
+  function remove(arr, item, compareOn) {
     if (angular.isArray(arr)) {
       for (var i = 0; i < arr.length; i++) {
-        if (angular.equals(arr[i], item)) {
+        if (angular.equals(arr[i], item) || arr[i][compareOn] == item[compareOn]) {
           arr.splice(i, 1);
           break;
         }
@@ -51,6 +47,8 @@ angular.module('checklist-model', [])
     var getter = $parse(attrs.checklistModel);
     var setter = getter.assign;
 
+    var compareOn = attrs.checklistCompareOn;
+
     // value added to list
     var value = $parse(attrs.checklistValue)(scope.$parent);
 
@@ -61,15 +59,15 @@ angular.module('checklist-model', [])
       } 
       var current = getter(scope.$parent);
       if (newValue === true) {
-        setter(scope.$parent, add(current, value));
+        setter(scope.$parent, add(current, value, compareOn));
       } else {
-        setter(scope.$parent, remove(current, value));
+        setter(scope.$parent, remove(current, value, compareOn));
       }
     });
 
     // watch original model change
     scope.$parent.$watch(attrs.checklistModel, function(newArr, oldArr) {
-      scope.checked = contains(newArr, value);
+      scope.checked = contains(newArr, value, compareOn);
     }, true);
   }
 


### PR DESCRIPTION
Passing an object property name to the checklist-compare-on attribute on the checkbox element allows to compare on that key, instead of the whole object. Useful when data differs between list and backend model assignment.