### PR TITLE
Fixed error with jquery (version 1.7.2) type property can't be changed.

### DIFF
--- a/checklist-model.js
+++ b/checklist-model.js
@@ -79,7 +79,7 @@ angular.module('checklist-model', [])
     terminal: true,
     scope: true,
     compile: function(tElement, tAttrs) {
-      if (tElement[0].tagName !== 'INPUT' || !tElement.attr('type', 'checkbox')) {
+      if (tElement[0].tagName !== 'INPUT' || tElement.attr('type') !== 'checkbox') {
         throw 'checklist-model should be applied to `input[type="checkbox"]`.';
       }
 


### PR DESCRIPTION
Apparently attr also wants to change the element. Using !== to check equality now

The error occured while using jquery version 1.7.2 Haven't checked if newer or older versions of jquery won't have this problem. However the !== equality check should have the same result.
