### PR TITLE
add checklist-change option since ng-change fires too early

### DIFF
--- a/checklist-model.js
+++ b/checklist-model.js
@@ -50,6 +50,7 @@ angular.module('checklist-model', [])
     // getter / setter for original model
     var getter = $parse(attrs.checklistModel);
     var setter = getter.assign;
+    var checklistChange = $parse(attrs.checklistChange);
 
     // value added to list
     var value = $parse(attrs.checklistValue)(scope.$parent);
@@ -64,6 +65,10 @@ angular.module('checklist-model', [])
         setter(scope.$parent, add(current, value));
       } else {
         setter(scope.$parent, remove(current, value));
+      }
+
+      if (checklistChange) {
+        checklistChange(scope);
       }
     });
 


### PR DESCRIPTION
Different from #33 in that it uses $parse and allows for more complex function calls. With this, checklist-change should work as a drop-in replacement for ng-change.