### PR TITLE
remove checklist-model attr with "data" prefix

### DIFF
--- a/checklist-model.js
+++ b/checklist-model.js
@@ -88,7 +88,7 @@ angular.module('checklist-model', [])
       }
 
       // exclude recursion
-      tElement.removeAttr('checklist-model');
+      tElement.removeAttr('checklist-model data-checklist-model');
       
       // local scope var storing individual checkbox model
       tElement.attr('ng-model', 'checked');


### PR DESCRIPTION
In order to avoid recursion in case we use the "data" prefix, it is necessary to remove it in the compile phase
