### PR TITLE
Support data- attributes. Fixes #16

### DIFF
--- a/checklist-model.js
+++ b/checklist-model.js
@@ -106,6 +106,10 @@ angular.module('checklist-model', [])
 
       // exclude recursion
       tElement.removeAttr('checklist-model');
+
+      //Fix for Issue #16
+      tElement.removeAttr('data-checklist-model');
+      tElement.removeAttr('x-checklist-model');
       
       // local scope var storing individual checkbox model
       tElement.attr('ng-model', 'checked');


### PR DESCRIPTION
A simple fix to resolve issue #16.  Some server side template engines require html templates to be valid xml.  This means "data-checkbox-model" must be used instead of "checkbox-model" per the html5 dtd.   This works with all the build in angular directives, so this plugin should behave the same way.