### PR TITLE
Support for angular material md-checkbox

### DIFF
--- a/checklist-model.js
+++ b/checklist-model.js
@@ -96,10 +96,6 @@ angular.module('checklist-model', [])
     terminal: true,
     scope: true,
     compile: function(tElement, tAttrs) {
-      if (tElement[0].tagName !== 'INPUT' || tAttrs.type !== 'checkbox') {
-        throw 'checklist-model should be applied to `input[type="checkbox"]`.';
-      }
-
       if (!tAttrs.checklistValue) {
         throw 'You should provide `checklist-value`.';
       }


### PR DESCRIPTION
I have use your plugin before and it work very well and now I decided to use angular material and found out that the check for element input and type checkbox are prevent us from using the checklist model with md-checkbox directive. To make it work again I have to remove the logic below to allow me to use your plugin. since angular material are gaining more usage is it a good idea to include a support for this ?