### PR TITLE
Added checklist-model to module exports for npm and webpack/browserify

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+require('./checklist-model');
+module.exports = 'checklist-model';
+

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "name": "Vitaliy Potapov",
     "email": "noginsk@rambler.ru"
   },
+  "main": "checklist-model.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/vitalets/checklist-model.git"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "name": "Vitaliy Potapov",
     "email": "noginsk@rambler.ru"
   },
-  "main": "index.js",
+  "main": "./index.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/vitalets/checklist-model.git"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "name": "Vitaliy Potapov",
     "email": "noginsk@rambler.ru"
   },
-  "main": "checklist-model.js",
+  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/vitalets/checklist-model.git"


### PR DESCRIPTION
Added `checklist-model` to exports so that after installing via npm, the package can be required in the angular module dependency list such as:

```angular.module('myApp', [require('checklist-model')]);```

This is helpful for Browserify and Webpack.