### PR TITLE
Use object equality for watching checklist value

### DIFF
--- a/checklist-model.js
+++ b/checklist-model.js
@@ -26,7 +26,7 @@ angular.module('checklist-model', [])
           arr.push(item);
       }
     return arr;
-  }  
+  }
 
   // remove
   function remove(arr, item, comparator) {
@@ -66,7 +66,7 @@ angular.module('checklist-model', [])
         comparator = function (a, b) {
           return a[comparatorExpression] === b[comparatorExpression];
         };
-        
+
       } else {
         comparator = $parse(attrs.checklistComparator)(scope.$parent);
       }
@@ -74,7 +74,7 @@ angular.module('checklist-model', [])
 
     // watch UI checked change
     scope.$watch(attrs.ngModel, function(newValue, oldValue) {
-      if (newValue === oldValue) { 
+      if (newValue === oldValue) {
         return;
       }
 
@@ -97,12 +97,12 @@ angular.module('checklist-model', [])
         checklistModelGetter.assign(scope.$parent, remove(current, oldValue, comparator));
         checklistModelGetter.assign(scope.$parent, add(current, newValue, comparator));
       }
-    });
+    }, true);
 
     function getChecklistValue() {
       return attrs.checklistValue ? $parse(attrs.checklistValue)(scope.$parent) : attrs.value;
     }
-    
+
     function setValueInChecklistModel(value, checked) {
       var current = checklistModelGetter(scope.$parent);
       if (angular.isFunction(checklistModelGetter.assign)) {
@@ -112,7 +112,7 @@ angular.module('checklist-model', [])
           checklistModelGetter.assign(scope.$parent, remove(current, value, comparator));
         }
       }
-      
+
     }
 
     // declare one function to be used for both $watch functions


### PR DESCRIPTION
Pull request https://github.com/vitalets/checklist-model/pull/111 introduced a watch on `getChecklistValue()`. However, if the `checklist-value` attribute returns the result of a function call like this,

```
<input type="checkbox" checklist-model="foo" checklist-value="getValue(bar)" />
```

then this watcher will keep firing, resulting in the error:

```
Uncaught Error: [$rootScope:infdig] 10 $digest() iterations reached. Aborting!
```

This is resolved by setting the `objectEquality` parameter of the `$watch` function to `true` (line 100).