### PR TITLE
Custom event variable, to know if checkbox was checked or unchecked

### DIFF
--- a/checklist-model.js
+++ b/checklist-model.js
@@ -86,7 +86,7 @@ angular.module('checklist-model', [])
       setValueInChecklistModel(getChecklistValue(), newValue);
 
       if (checklistChange) {
-        checklistChange(scope);
+        checklistChange(scope, { "$checked": newValue });
       }
     });
 

--- a/docs/blocks/event/ctrl.js
+++ b/docs/blocks/event/ctrl.js
@@ -7,7 +7,14 @@ app.controller('Ctrl5', function($scope) {
   };
 
   $scope.testValue = 'Im not changed yet!';
-  $scope.imChanged = function(){
+  $scope.imChanged = function(checked, key) {
+    if (checked) {
+      console.log(key + " activated")
+    }
+    else {
+      console.log(key + " deactivated")
+    }
+
     $scope.testValue = $scope.user.roles.join(',');
   }
   $scope.shouldChange = function(key){

--- a/docs/blocks/event/view.html
+++ b/docs/blocks/event/view.html
@@ -1,3 +1,3 @@
 <label ng-repeat="(key, text) in roles">
-  <input type="checkbox" checklist-before-change="shouldChange(key)" checklist-change="imChanged()" checklist-model="user.roles" checklist-value="key"> {{text}}
+  <input type="checkbox" checklist-before-change="shouldChange(key)" checklist-change="imChanged($checked, key)" checklist-model="user.roles" checklist-value="key"> {{text}}
 </label>

--- a/index.html
+++ b/index.html
@@ -909,7 +909,7 @@ app.controller('Ctrl6a', function($scope) {
         <div class="col-xs-12 col-sm-6">
           <h3>demo</h3>
           <div class="well"><label ng-repeat="(key, text) in roles">
-  <input type="checkbox" checklist-before-change="shouldChange(key)" checklist-change="imChanged()" checklist-model="user.roles" checklist-value="key"> {{text}}
+  <input type="checkbox" checklist-before-change="shouldChange(key)" checklist-change="imChanged($checked, key)" checklist-model="user.roles" checklist-value="key"> {{text}}
 </label></div>
           <script>app.controller('Ctrl5', function($scope) {
   $scope.roles = {
@@ -920,7 +920,14 @@ app.controller('Ctrl6a', function($scope) {
   };
 
   $scope.testValue = 'Im not changed yet!';
-  $scope.imChanged = function(){
+  $scope.imChanged = function(checked, key) {
+    if (checked) {
+      console.log(key + " activated")
+    }
+    else {
+      console.log(key + " deactivated")
+    }
+
     $scope.testValue = $scope.user.roles.join(',');
   }
   $scope.shouldChange = function(key){
@@ -963,7 +970,7 @@ console.log("should change " + key);
         <div class="col-xs-12">
           <h3>html</h3>
           <pre class="prettyprint ng-non-bindable">&lt;label ng-repeat=&quot;(key, text) in roles&quot;&gt;
-  &lt;input type=&quot;checkbox&quot; checklist-before-change=&quot;shouldChange(key)&quot; checklist-change=&quot;imChanged()&quot; checklist-model=&quot;user.roles&quot; checklist-value=&quot;key&quot;&gt; {{text}}
+  &lt;input type=&quot;checkbox&quot; checklist-before-change=&quot;shouldChange(key)&quot; checklist-change=&quot;imChanged($checked, key)&quot; checklist-model=&quot;user.roles&quot; checklist-value=&quot;key&quot;&gt; {{text}}
 &lt;/label&gt;</pre>
           <h3>js</h3>
           <pre class="prettyprint">var app = angular.module(&quot;app&quot;, [&quot;checklist-model&quot;]);
@@ -976,7 +983,14 @@ app.controller('Ctrl5', function($scope) {
   };
 
   $scope.testValue = 'Im not changed yet!';
-  $scope.imChanged = function(){
+  $scope.imChanged = function(checked, key) {
+    if (checked) {
+      console.log(key + &quot; activated&quot;)
+    }
+    else {
+      console.log(key + &quot; deactivated&quot;)
+    }
+
     $scope.testValue = $scope.user.roles.join(',');
   }
   $scope.shouldChange = function(key){


### PR DESCRIPTION
`checklist-change` event allows a custom function call, but you don't know if the user clicked the checkbox to "check" it or "uncheck" it. With this pull request you can. 

I think #127 kind of wants this, but in the `checklist-change-before` function? Not entirely sure. 