### PR TITLE
add support for commonjs

### DIFF
--- a/checklist-model.js
+++ b/checklist-model.js
@@ -5,6 +5,11 @@
  * License: MIT http://opensource.org/licenses/MIT
  */
 
+ /* commonjs package manager support (eg componentjs) */
+ if (typeof module !== "undefined" && typeof exports !== "undefined" && module.exports === exports){
+   module.exports = 'checklist-model';
+ }
+
 angular.module('checklist-model', [])
 .directive('checklistModel', ['$parse', '$compile', function($parse, $compile) {
   // contains


### PR DESCRIPTION
This patch will allow tools like browserify to import checklist-model when pulled from npm.