### PR TITLE
trigger jQuery change event on data change

### DIFF
--- a/checklist-model.js
+++ b/checklist-model.js
@@ -96,6 +96,9 @@ angular.module('checklist-model', [])
 
       setValueInChecklistModel(getChecklistValue(), newValue);
 
+      // trigger change event for jQuery
+      elem.change();
+
       if (checklistChange) {
         checklistChange(scope);
       }


### PR DESCRIPTION
Angular checklist-model did not fired change event for jQuery, when the data set (model) was changed externally. This PR should fix it by issuing `jQuery.change()` on the checkbox element.