### PR TITLE
fix(package.json) Move AngularJS as a `peerDependency`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,17 +2,17 @@
   "name": "checklist-model",
   "description": "AngularJS directive for list of checkboxes",
   "license": "MIT",
-  "version": "0.11.0",
+  "version": "1.0.0",
   "homepage": "http://vitalets.github.io/checklist-model",
   "author": {
     "name": "Vitaliy Potapov",
     "email": "noginsk@rambler.ru"
   },
   "contributors": [
-  {
-    "name": "Adrian Ber",
-    "email": "beradrian@yahoo.com"
-  }
+    {
+      "name": "Adrian Ber",
+      "email": "beradrian@yahoo.com"
+    }
   ],
   "repository": {
     "type": "git",
@@ -22,7 +22,7 @@
   "engines": {
     "node": ">= 0.8.0"
   },
-  "dependencies": {
+  "peerDependencies": {
     "angular": ">=1.0.8"
   },
   "devDependencies": {
@@ -43,5 +43,6 @@
     "grunt-jsdoc": "~0.4.1",
     "grunt-shell": "~0.5.0",
     "grunt-bump": "0.0.13"
-  }
+  },
+  "dependencies": {}
 }

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,7 @@ Please, try out
 ````js
 var app = angular.module("app", ["checklist-model"]);
 ````
+> Since version `1.0.0` you *must* install the `angular` library yourself as it is now a [`peerDependency`](https://nodejs.org/en/blog/npm/peer-dependencies/)
 
 ## How to get support
 * Ask a question on StackOverflow and tag it with [checklist-model](http://stackoverflow.com/questions/tagged/checklist-model).


### PR DESCRIPTION
AngularJS is now a `peerDependency` and it has to be installed separately. This is a breaking change, so the `package.json`
version was bumped to a `1.0.0`. 

### Rationale
The default NPM dependency resolution usually works just fine with the explicit dependency, but it
also introduce some weird behaviors, like allowing two versions of the same library to co-exist. Since it is generally a _bad idea_ to have
two concurrent AngularJS versions installed, turning it into a `peerDependency` makes more sense and give the user of this library all
control over AngularJS installation.

https://nodejs.org/en/blog/npm/peer-dependencies/